### PR TITLE
Move react-draggable to peerDepencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "webpack-dev-server": "^1.8.0"
   },
   "dependencies": {
-    "object-assign": "^2.0.0",
+    "object-assign": "^2.0.0"
+  },
+  "peerDependencies": {
     "react-draggable": "^0.8.1"
   },
   "publishConfig": {


### PR DESCRIPTION
I can overwrite the react-draggable installation in the package.json of my project if it is defined like this. I thinks this is how dependencies should be declared in npm3 if I understand correctly.

Would you merge this and release a new version?
What can I do to help?