### PR TITLE
Moving react-dom from devDependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "lodash": "^3.10.1",
     "pre-commit": "^1.1.2",
     "react": "^0.14.2",
-    "react-dom": "^0.14.2",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.6",
     "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
+    "react-dom": "^0.14.2",
     "object-assign": "^4.0.1",
     "react-draggable": "^1.1.0"
   },


### PR DESCRIPTION
When I do a:

```
var Resizable = require('react-resizable');
```

I get:

**Error: Cannot find module 'react-dom'**


react-resizable has been installed via `npm install react-resizable --save`