### PR TITLE
switch to ES2015 loose mode to fix issue with ie9 and 10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "es2015-loose",
     "stage-1",
     "react"
   ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-core": "^6.5.1",
     "babel-eslint": "^4.1.8",
     "babel-loader": "^6.2.2",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "cross-env": "^1.0.7",


### PR DESCRIPTION
This has been done on the react-grid-layout to fix a similar issue with "this" being unbounded in IE 9 and 10. Error was still appearing to come from the resizable library, I made change to loose mode and that fixed the issue.