### PR TITLE
Allow restricting of resizing by axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the example and associated code in [TestLayout](/test/TestLayout.jsx) and
 Make sure you use the associated styles in [/css/styles.css](/css/styles.css), as without them, you will have
 problems with handle placement and visibility.
 
-You can pass options directly to the underlying `Draggable` instance by using the prop `draggableOpts`.
+You can pass options directly to the underlying `DraggableCore` instance by using the prop `draggableOpts`.
 See the [demo](/test/TestLayout.jsx) for more on this.
 
 ### Installation
@@ -63,7 +63,11 @@ draggableOpts: React.PropTypes.object
 
 ```js
 {
-lockAspectRatio: React.PropTypes.bool, // Preserves aspect
+// Preserves aspect ratio (default: false)
+lockAspectRatio: React.PropTypes.bool,
+
+// Restricts resizing to a particular axis (default: 'both')
+axis: React.PropTypes.oneOf(['both', 'x', 'y', 'none']),
 
 // Constaints coords, pass [x,y]
 minConstraints: React.PropTypes.arrayOf(React.PropTypes.number),

--- a/lib/Resizable.jsx
+++ b/lib/Resizable.jsx
@@ -42,6 +42,13 @@ export default class Resizable extends React.Component {
     // If true, will only allow width/height to move in lockstep
     lockAspectRatio: PropTypes.bool,
 
+    // Restricts resizing to a particular axis (default: 'both')
+    // 'both' - allows resizing by width or height
+    // 'x' - only allows the width to be changed
+    // 'y' - only allows the height to be changed
+    // 'none' - disables resizing altogether
+    axis: PropTypes.oneOf(['both', 'x', 'y', 'none']),
+
     // Min/max size
     minConstraints: PropTypes.arrayOf(PropTypes.number),
     maxConstraints: PropTypes.arrayOf(PropTypes.number),
@@ -58,6 +65,7 @@ export default class Resizable extends React.Component {
   static defaultProps =  {
     handleSize: [20, 20],
     lockAspectRatio: false,
+    axis: 'both',
     minConstraints: [20, 20],
     maxConstraints: [Infinity, Infinity]
   };
@@ -133,6 +141,13 @@ export default class Resizable extends React.Component {
    */
   resizeHandler(handlerName: string): Function {
     return (e: Event, {node, deltaX, deltaY}: DragCallbackData) => {
+      if (this.props.axis === 'y' || this.props.axis === 'none') {
+        deltaX = 0;
+      }
+      if (this.props.axis === 'x' || this.props.axis === 'none') {
+        deltaY = 0;
+      }
+
       let width = this.state.width + deltaX;
       let height = this.state.height + deltaY;
 
@@ -165,8 +180,8 @@ export default class Resizable extends React.Component {
 
   render(): React.Element<any> {
     // eslint-disable-next-line no-unused-vars
-    const {children, draggableOpts, width, height,
-        handleSize, lockAspectRatio, minConstraints, maxConstraints, onResize,
+    const {children, draggableOpts, width, height, handleSize,
+        lockAspectRatio, axis, minConstraints, maxConstraints, onResize,
         onResizeStop, onResizeStart, ...p} = this.props;
 
     const className = p.className ?

--- a/lib/ResizableBox.jsx
+++ b/lib/ResizableBox.jsx
@@ -35,7 +35,7 @@ export default class ResizableBox extends React.Component {
     // If you use Resizable directly, you are responsible for updating the child component
     // with a new width and height.
     const {handleSize, onResize, onResizeStart, onResizeStop, draggableOpts,
-         minConstraints, maxConstraints, lockAspectRatio, width, height, ...props} = this.props;
+         minConstraints, maxConstraints, lockAspectRatio, axis, width, height, ...props} = this.props;
     return (
       <Resizable
         handleSize={handleSize}
@@ -48,6 +48,7 @@ export default class ResizableBox extends React.Component {
         minConstraints={minConstraints}
         maxConstraints={maxConstraints}
         lockAspectRatio={lockAspectRatio}
+        axis={axis}
         >
         <div style={{width: this.state.width + 'px', height: this.state.height + 'px'}} {...props} />
       </Resizable>


### PR DESCRIPTION
Just like react-draggable. Pass in a prop `axis` taking options of `both`, `x`, `y`, and `none`.

Perhaps this belongs in DraggableCore, but it was easy enough to implement here directly.
