### PR TITLE
Remove source files and the build script from the npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
 examples/
 test/
-lib/
-build.sh
 *.config.js

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 rm -rf ./build
-./node_modules/.bin/babel --out-dir ./build ./lib
+if [ -d ./node_modules ]; then
+  ./node_modules/.bin/babel --out-dir ./build ./lib
+else
+  ../.bin/babel --out-dir ./build ./lib
+fi
 # More cross-platform compatible than `rename`
 find ./build -type f -name '*.jsx' -exec sh -c 'mv -f $0 ${0%.jsx}.js' {} \;


### PR DESCRIPTION
...so that npm can build locally when using a git dependency. You know, like when you have a commit point in a custom fork you want to use:

    {
      "dependencies": {
        "react-resizable": "github:dnissley-al/react-resizable#c3cd595"
      }
    }

If you put the build script and source files in .npmignore file, the prepublish task seems to silently fail when it doesn't find the build script. This leaves the installed package in a strange state with no sources, no build script, and no build either. That's strange and bad, in my opinion -- github dependencies should probably just not ignore any files. But hey... that's where we are.