### PR TITLE
fix(ResizableBox.jsx): Unknown prop `onResize`

### DIFF
--- a/lib/ResizableBox.jsx
+++ b/lib/ResizableBox.jsx
@@ -35,7 +35,7 @@ export default class ResizableBox extends React.Component {
     // Basic wrapper around a Resizable instance.
     // If you use Resizable directly, you are responsible for updating the child component
     // with a new width and height.
-    const {handleSize, onResizeStart, onResizeStop, draggableOpts,
+    const {handleSize, onResize, onResizeStart, onResizeStop, draggableOpts,
          minConstraints, maxConstraints, lockAspectRatio, width, height, ...props} = this.props;
     return (
       <Resizable


### PR DESCRIPTION
"Unknown prop `onResize` on `<div>` tag" reported by React 15.x.

This should be released as a hotfix.