### PR TITLE
Resizeable Component based on scale/zoom level of Parent Div(container)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,17 +1,59 @@
 .react-resizable {
   position: relative;
+  border: 2px dashed #00b8ff;
+  overflow: visible !important;
 }
-.react-resizable-handle {
+.react-resizable-handle-se {
   position: absolute;
   width: 20px;
   height: 20px;
-  bottom: 0;
-  right: 0;
-  background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pg08IS0tIEdlbmVyYXRvcjogQWRvYmUgRmlyZXdvcmtzIENTNiwgRXhwb3J0IFNWRyBFeHRlbnNpb24gYnkgQWFyb24gQmVhbGwgKGh0dHA6Ly9maXJld29ya3MuYWJlYWxsLmNvbSkgLiBWZXJzaW9uOiAwLjYuMSAgLS0+DTwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DTxzdmcgaWQ9IlVudGl0bGVkLVBhZ2UlMjAxIiB2aWV3Qm94PSIwIDAgNiA2IiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjojZmZmZmZmMDAiIHZlcnNpb249IjEuMSINCXhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbDpzcGFjZT0icHJlc2VydmUiDQl4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjZweCIgaGVpZ2h0PSI2cHgiDT4NCTxnIG9wYWNpdHk9IjAuMzAyIj4NCQk8cGF0aCBkPSJNIDYgNiBMIDAgNiBMIDAgNC4yIEwgNCA0LjIgTCA0LjIgNC4yIEwgNC4yIDAgTCA2IDAgTCA2IDYgTCA2IDYgWiIgZmlsbD0iIzAwMDAwMCIvPg0JPC9nPg08L3N2Zz4=');
-  background-position: bottom right;
-  padding: 0 3px 3px 0;
-  background-repeat: no-repeat;
-  background-origin: content-box;
+  bottom: -10px;
+  right: -10px;
+  background-color: #00b8ff;
+  border: 5px solid #dcdcdc;
+  border-radius: 10px;
+  box-shadow: 0px 0px 5px #717171;
   box-sizing: border-box;
   cursor: se-resize;
+}
+.react-resizable-handle-nw {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  top: -10px;
+  left: -10px;
+  background-color: #00b8ff;
+  border: 5px solid #dcdcdc;
+  border-radius: 10px;
+  box-shadow: 0px 0px 5px #717171;
+  box-sizing: border-box;
+  cursor: nw-resize;
+}
+
+.react-resizable-handle-ne {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  top: -10px;
+  right: -10px;
+  background-color: #00b8ff;
+  border: 5px solid #dcdcdc;
+  border-radius: 10px;
+  box-shadow: 0px 0px 5px #717171;
+  box-sizing: border-box;
+  cursor: ne-resize;
+}
+
+.react-resizable-handle-sw {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  bottom: -10px;
+  left: -10px;
+  background-color: #00b8ff;
+  border: 5px solid #dcdcdc;
+  border-radius: 10px;
+  box-shadow: 0px 0px 5px #717171;
+  box-sizing: border-box;
+  cursor: sw-resize;
 }

--- a/lib/Resizable.jsx
+++ b/lib/Resizable.jsx
@@ -166,7 +166,7 @@ export default class Resizable extends React.Component {
    * @param  {String} handlerName Handler name to wrap.
    * @return {Function}           Handler function.
    */
-  resizeHandler(handlerName: string): Function {
+  resizeHandler(handlerName: string, resizeDirection: string): Function {
     return (e: SyntheticEvent | MouseEvent, {node, deltaX, deltaY}: DragCallbackData) => {
 
       // Axis restrictions
@@ -176,9 +176,22 @@ export default class Resizable extends React.Component {
       let zoomMultiplier = 1/this.state.zoomLevel;
 
       // Update w/h
-      let width = this.state.width + (canDragX ? deltaX*zoomMultiplier : 0);
-      let height = this.state.height + (canDragY ? deltaY*zoomMultiplier : 0);
+      let width = this.state.width;
+      let height = this.state.height;
 
+      if(resizeDirection === "se") {
+        width += (canDragX ? deltaX*zoomMultiplier : 0);
+        height += (canDragY ? deltaY*zoomMultiplier : 0);
+      } else if (resizeDirection === "nw") {
+        width -= (canDragX ? deltaX*zoomMultiplier : 0);
+        height -= (canDragY ? deltaY*zoomMultiplier : 0);
+      } else if (resizeDirection === "ne") {
+        width += (canDragX ? deltaX*zoomMultiplier : 0);
+        height -= (canDragY ? deltaY*zoomMultiplier : 0);
+      } else if (resizeDirection === "sw") {
+        width -= (canDragX ? deltaX*zoomMultiplier : 0);
+        height += (canDragY ? deltaY*zoomMultiplier : 0);
+      }
       // Early return if no change
       const widthChanged = width !== this.state.width, heightChanged = height !== this.state.height;
       if (handlerName === 'onResize' && !widthChanged && !heightChanged) return;
@@ -202,7 +215,7 @@ export default class Resizable extends React.Component {
       const hasCb = typeof this.props[handlerName] === 'function';
       if (hasCb) {
         if (typeof e.persist === 'function') e.persist();
-        this.setState(newState, () => this.props[handlerName](e, {node, size: {width, height}}));
+        this.setState(newState, () => this.props[handlerName](e, {node, size: {width, height}, resizeDirection}));
       } else {
         this.setState(newState);
       }
@@ -230,12 +243,39 @@ export default class Resizable extends React.Component {
         children.props.children,
         <DraggableCore
           {...draggableOpts}
-          key="resizableHandle"
-          onStop={this.resizeHandler('onResizeStop')}
-          onStart={this.resizeHandler('onResizeStart')}
-          onDrag={this.resizeHandler('onResize')}
+          key="resizableHandle-nw"
+          onStop={this.resizeHandler('onResizeStop','nw')}
+          onStart={this.resizeHandler('onResizeStart','nw')}
+          onDrag={this.resizeHandler('onResize','nw')}
           >
-          <span className="react-resizable-handle" />
+          <span className="react-resizable-handle-nw" />
+        </DraggableCore>,
+        <DraggableCore
+          {...draggableOpts}
+          key="resizableHandle-ne"
+          onStop={this.resizeHandler('onResizeStop','ne')}
+          onStart={this.resizeHandler('onResizeStart','ne')}
+          onDrag={this.resizeHandler('onResize','ne')}
+          >
+          <span className="react-resizable-handle-ne" />
+        </DraggableCore>,
+        <DraggableCore
+          {...draggableOpts}
+          key="resizableHandle-se"
+          onStop={this.resizeHandler('onResizeStop','se')}
+          onStart={this.resizeHandler('onResizeStart','se')}
+          onDrag={this.resizeHandler('onResize','se')}
+          >
+          <span className="react-resizable-handle-se" />
+        </DraggableCore>,
+        <DraggableCore
+          {...draggableOpts}
+          key="resizableHandle-sw"
+          onStop={this.resizeHandler('onResizeStop','sw')}
+          onStart={this.resizeHandler('onResizeStart','sw')}
+          onDrag={this.resizeHandler('onResize','sw')}
+          >
+          <span className="react-resizable-handle-sw" />
         </DraggableCore>
       ]
     });

--- a/lib/Resizable.jsx
+++ b/lib/Resizable.jsx
@@ -7,6 +7,7 @@ export type Props = {
   children: React.Element<any>,
   width: number,
   height: number,
+  zoomLevel: number,
   handleSize: [number, number],
   lockAspectRatio: boolean,
   axis: Axis,
@@ -24,7 +25,8 @@ type Position = {
 type State = {
   resizing: boolean,
   width: number, height: number,
-  slackW: number, slackH: number
+  slackW: number, slackH: number,
+  zoomLevel: number
 };
 type DragCallbackData = {
   node: HTMLElement,
@@ -58,6 +60,9 @@ export default class Resizable extends React.Component {
     // If you change this, be sure to update your css
     handleSize: PropTypes.array,
 
+    // Zoom defaults to 1
+    zoomLevel: PropTypes.number,
+
     // If true, will only allow width/height to move in lockstep
     lockAspectRatio: PropTypes.bool,
 
@@ -87,13 +92,15 @@ export default class Resizable extends React.Component {
     lockAspectRatio: false,
     axis: 'both',
     minConstraints: [20, 20],
-    maxConstraints: [Infinity, Infinity]
+    maxConstraints: [Infinity, Infinity],
+    zoomLevel: 1
   };
 
   state: State = {
     resizing: false,
     width: this.props.width, height: this.props.height,
-    slackW: 0, slackH: 0
+    slackW: 0, slackH: 0,
+    zoomLevel: this.props.zoomLevel
   };
 
   componentWillReceiveProps(nextProps: Object) {
@@ -166,9 +173,11 @@ export default class Resizable extends React.Component {
       const canDragX = this.props.axis === 'both' || this.props.axis === 'x';
       const canDragY = this.props.axis === 'both' || this.props.axis === 'y';
 
+      let zoomMultiplier = 1/this.state.zoomLevel;
+
       // Update w/h
-      let width = this.state.width + (canDragX ? deltaX : 0);
-      let height = this.state.height + (canDragY ? deltaY : 0);
+      let width = this.state.width + (canDragX ? deltaX*zoomMultiplier : 0);
+      let height = this.state.height + (canDragY ? deltaY*zoomMultiplier : 0);
 
       // Early return if no change
       const widthChanged = width !== this.state.width, heightChanged = height !== this.state.height;


### PR DESCRIPTION
Added a feature of Zoom Level.

So if the parent container of the resize-able component is zoomed out (`transform: scale(2)`) or zoomed in (`transform: scale(0.5)`) then resized element behaves as expected.

By default zoomLevel prop is set to 1, hence no scaling is required.
if the zoomLevel prop is present the appropriate scaling is done.