### PR TITLE
lock aspect ratio if shift key is down

### DIFF
--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -112,10 +112,10 @@ export default class Resizable extends React.Component<Props, State> {
   }
 
   // If you do this, be careful of constraints
-  runConstraints(width: number, height: number): [number, number] {
+  runConstraints(width: number, height: number, shiftKeyDown: boolean): [number, number] {
     const [min, max] = [this.props.minConstraints, this.props.maxConstraints];
 
-    if (this.props.lockAspectRatio) {
+    if (this.props.lockAspectRatio || shiftKeyDown) {
       const ratio = this.state.width / this.state.height;
       height = width / ratio;
       width = height * ratio;
@@ -158,7 +158,7 @@ export default class Resizable extends React.Component<Props, State> {
    * @return {Function}           Handler function.
    */
   resizeHandler(handlerName: string): Function {
-    return (e: SyntheticEvent<> | MouseEvent, {node, deltaX, deltaY}: DragCallbackData) => {
+    return (e: SyntheticMouseEvent<> | MouseEvent, {node, deltaX, deltaY}: DragCallbackData) => {
 
       // Axis restrictions
       const canDragX = this.props.axis === 'both' || this.props.axis === 'x';
@@ -172,7 +172,7 @@ export default class Resizable extends React.Component<Props, State> {
       const widthChanged = width !== this.state.width, heightChanged = height !== this.state.height;
       if (handlerName === 'onResize' && !widthChanged && !heightChanged) return;
 
-      [width, height] = this.runConstraints(width, height);
+      [width, height] = this.runConstraints(width, height, e.shiftKey);
 
       // Set the appropriate state for this handler.
       const newState = {};


### PR DESCRIPTION
Implements #77 

Note: Flow is currently failing due to `SyntheticEvent` not having a `shiftKey` prop. I updated to use `SyntheticMouseEvent` but that doesn't seem to be defined.