### PR TITLE
new react getDerivedStateFromProps

### DIFF
--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -114,7 +114,7 @@ export default class Resizable extends React.Component<Props, State> {
     slackW: 0, slackH: 0
   };
 
-  componentWillReceiveProps(nextProps: Object) {
+  UNSAFE_componentWillReceiveProps(nextProps: Object) {
     // If parent changes height/width, set that in our state.
     if (!this.state.resizing &&
         (nextProps.width !== this.props.width || nextProps.height !== this.props.height)) {

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -114,15 +114,17 @@ export default class Resizable extends React.Component<Props, State> {
     slackW: 0, slackH: 0
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps: Object) {
+  static getDerivedStateFromProps(props: Object, state:Object) {
     // If parent changes height/width, set that in our state.
-    if (!this.state.resizing &&
-        (nextProps.width !== this.props.width || nextProps.height !== this.props.height)) {
-      this.setState({
-        width: nextProps.width,
-        height: nextProps.height
-      });
-    }
+    if (!state.resizing &&
+        (props.width !== props.width || props.height !== props.height)) {
+      return {
+        width: props.width,
+        height: props.height
+      };
+    } 
+    
+    return null;
   }
 
   lockAspectRatio(width: number, height: number, aspectRatio: number): [number, number] {

--- a/lib/ResizableBox.js
+++ b/lib/ResizableBox.js
@@ -35,7 +35,7 @@ export default class ResizableBox extends React.Component<ResizableProps, State>
     }
   };
 
-  componentWillReceiveProps(nextProps: ResizableProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: ResizableProps) {
     if (nextProps.width !== this.props.width || nextProps.height !== this.props.height) {
       this.setState({
         width: nextProps.width,

--- a/lib/ResizableBox.js
+++ b/lib/ResizableBox.js
@@ -35,13 +35,15 @@ export default class ResizableBox extends React.Component<ResizableProps, State>
     }
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps: ResizableProps) {
-    if (nextProps.width !== this.props.width || nextProps.height !== this.props.height) {
-      this.setState({
-        width: nextProps.width,
-        height: nextProps.height
-      });
+  static getDerivedStateFromProps(props: ResizableProps, state:Object) {
+    if (props.width !== props.width || props.height !== props.height) {
+      return {
+        width: props.width,
+        height: props.height
+      };
     }
+
+    return null;
   }
 
   render(): ReactNode {


### PR DESCRIPTION
Just a simple quick fix to get rid of the react 17.x messages. If you guys think this is not the best way to resolve it and would rather go the componentDidUpdate route feel free to delete this PR.