### PR TITLE
Resolve warning about getDerivedStateFromProps

### DIFF
--- a/lib/ResizableBox.js
+++ b/lib/ResizableBox.js
@@ -38,6 +38,7 @@ export default class ResizableBox extends React.Component<ResizableProps, State>
         propsHeight: props.height,
       };
     }
+    return null;
   }
 
   onResize = (e: SyntheticEvent<>, data: ResizeCallbackData) => {


### PR DESCRIPTION
Closes #116

This change should resolve warning mentioned in this issue https://github.com/facebook/react/issues/12562

`getDerivedStateFromProps(): A valid state object (or null) must be returned`

