### PR TITLE
Fix top-left resizing - account for new position when calling back onResize

### DIFF
--- a/__tests__/Resizable.test.js
+++ b/__tests__/Resizable.test.js
@@ -64,34 +64,110 @@ describe('render Resizable', () => {
     });
   });
 
-  test('onResize callback after modified position', () => {
+  describe('onResize callback with modified position', () => {
     const customProps = {
       ...props,
-      resizeHandles: ['nw', 'sw' ,'nw', 'se', 'n', 's', 'w', 'e'],
+      resizeHandles: ['nw', 'sw' ,'ne', 'se', 'n', 's', 'w', 'e'],
     };
-    const eventTarget = {
-      top: 0,
+    const mockClientRect = {
       left: 0,
+      top: 0,
     };
+    const eventTarget = document.createElement('div');
+    // $FlowIgnore need to override to have control over dummy dom element
+    eventTarget.getBoundingClientRect = () => ({ ...mockClientRect });
     const mockEvent = { target: eventTarget };
     const element = shallow(<Resizable {...customProps}>{resizableBoxChildren}</Resizable>);
-    expect(props.onResize).not.toHaveBeenCalled();
-    element.find('DraggableCore').first().prop('onDrag')(
-      mockEvent,
-      {
-        node: null,
-        deltaX: 5,
-        deltaY: 10,
-      }
-    );
-    expect(props.onResize).lastCalledWith(
-      mockEvent,
-      expect.objectContaining({
-        size: {
-          height: 40,
-          width: 45,
-        },
-      })
-    );
+    const nwHandle = element.find('DraggableCore').first();
+
+    test('Gradual resizing without movement between does not modify callback', () => {
+      expect(props.onResize).not.toHaveBeenCalled();
+      nwHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 5, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 40,
+            width: 45,
+          },
+        })
+      );
+    });
+
+    test('Movement between callbacks modifies response values', () => {
+      expect(props.onResize).not.toHaveBeenCalled();
+
+      mockClientRect.top = -10; // Object moves between callbacks
+      nwHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 5, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 50, // No height change since deltaY is caused by clientRect moving vertically
+            width: 45,
+          },
+        })
+      );
+
+      mockClientRect.left = 20; // Object moves between callbacks
+      nwHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 5, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 40, // Height decreased as deltaY increases - no further top position change since last
+            width: 25, // Width decreased 25 - 5 from deltaX and 20 from changing position
+          },
+        })
+      );
+
+      props.onResize.mockClear();
+      mockClientRect.left -= 10; // Object moves between callbacks
+      mockClientRect.top -= 10; // Object moves between callbacks
+      nwHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 10, deltaY: 10 });
+      expect(props.onResize).not.toHaveBeenCalled();
+
+      mockClientRect.left -= 10; // Object moves between callbacks
+      mockClientRect.top -= 10; // Object moves between callbacks
+      const swHandle = element.find('DraggableCore').at(1);
+      swHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 10, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 60, // Changed since resizing from bottom doesn't cause position change
+            width: 50, // No change - movement has caused entire delta
+          },
+        })
+      );
+
+      mockClientRect.left -= 10; // Object moves between callbacks
+      mockClientRect.top -= 10; // Object moves between callbacks
+      const neHandle = element.find('DraggableCore').at(2);
+      neHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 10, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 50, // No change - movement has caused entire delta
+            width: 60, // Changed since resizing from right doesn't cause position change
+          },
+        })
+      );
+
+      mockClientRect.left -= 10; // Object moves between callbacks
+      mockClientRect.top -= 10; // Object moves between callbacks
+      const seHandle = element.find('DraggableCore').at(3);
+      seHandle.prop('onDrag')(mockEvent, { node: null, deltaX: 10, deltaY: 10 });
+      expect(props.onResize).lastCalledWith(
+        mockEvent,
+        expect.objectContaining({
+          size: {
+            height: 60, // Changed since resizing from right doesn't cause position change
+            width: 60, // Changed since resizing from right doesn't cause position change
+          },
+        })
+      );
+    });
   });
 });

--- a/__tests__/Resizable.test.js
+++ b/__tests__/Resizable.test.js
@@ -63,4 +63,35 @@ describe('render Resizable', () => {
       expect(element.find('.custom-component-se')).toHaveLength(1);
     });
   });
+
+  test('onResize callback after modified position', () => {
+    const customProps = {
+      ...props,
+      resizeHandles: ['nw', 'sw' ,'nw', 'se', 'n', 's', 'w', 'e'],
+    };
+    const eventTarget = {
+      top: 0,
+      left: 0,
+    };
+    const mockEvent = { target: eventTarget };
+    const element = shallow(<Resizable {...customProps}>{resizableBoxChildren}</Resizable>);
+    expect(props.onResize).not.toHaveBeenCalled();
+    element.find('DraggableCore').first().prop('onDrag')(
+      mockEvent,
+      {
+        node: null,
+        deltaX: 5,
+        deltaY: 10,
+      }
+    );
+    expect(props.onResize).lastCalledWith(
+      mockEvent,
+      expect.objectContaining({
+        size: {
+          height: 40,
+          width: 45,
+        },
+      })
+    );
+  });
 });

--- a/examples/1.html
+++ b/examples/1.html
@@ -7,12 +7,19 @@
       }
       #content {
         width: 100%;
-        background: #eee;
         padding-bottom: 250px;
       }
       .layoutRoot {
         display: flex;
+        background: #eee;
+        margin-bottom: 20px;
         flex-wrap: wrap;
+      }
+      .absoluteLayout {
+        height: 600px;
+        position: relative;
+        justify-content: center;
+        align-items: center
       }
       .box {
         display: inline-block;
@@ -41,6 +48,24 @@
       }
       .box3:hover .react-resizable-handle {
         display: block;
+      }
+      .absolutely-positioned {
+        position: absolute !important;
+      }
+      .center-aligned {
+        margin: auto;
+      }
+      .left-aligned {
+        left: 0;
+      }
+      .right-aligned {
+        right: 0;
+      }
+      .top-aligned {
+        top: 0;
+      }
+      .bottom-aligned {
+        bottom: 0;
       }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>

--- a/examples/1.html
+++ b/examples/1.html
@@ -8,7 +8,7 @@
       #content {
         width: 100%;
         background: #eee;
-        padding-bottom: 200px;
+        padding-bottom: 250px;
       }
       .layoutRoot {
         display: flex;

--- a/examples/ExampleLayout.js
+++ b/examples/ExampleLayout.js
@@ -10,12 +10,19 @@ export default class ExampleLayout extends React.Component<{}, {width: number, h
     height: 200,
     fixedWidth: 200,
     fixedHeight: 200,
-    fixedLeft: 100,
-    fixedTop: 500
+    fixedLeft: 27,
+    fixedTop: 920
   };
 
   onClick = () => {
-    this.setState({width: 200, height: 200});
+    this.setState({
+      width: 200,
+      height: 200,
+      fixedWidth: 200,
+      fixedHeight: 200,
+      fixedLeft: 27,
+      fixedTop: 920
+    });
   };
 
   onResize = (event, {element, size, handle}) => {

--- a/examples/ExampleLayout.js
+++ b/examples/ExampleLayout.js
@@ -2,52 +2,50 @@ import React from 'react';
 import Resizable from '../lib/Resizable';
 import ResizableBox from '../lib/ResizableBox';
 import 'style-loader!css-loader!../css/styles.css';
-import 'style-loader!css-loader!./test.css';
+import 'style-loader!css-loader!./example.css';
 
 export default class ExampleLayout extends React.Component<{}, {width: number, height: number}> {
   state = {
     width: 200,
     height: 200,
-    fixedWidth: 200,
-    fixedHeight: 200,
-    fixedLeft: 27,
-    fixedTop: 920
+    absoluteWidth: 200,
+    absoluteHeight: 200,
+    absoluteLeft: 0,
+    absoluteTop: 0,
   };
 
   onClick = () => {
-    this.setState({
-      width: 200,
-      height: 200,
-      fixedWidth: 200,
-      fixedHeight: 200,
-      fixedLeft: 27,
-      fixedTop: 920
-    });
+    this.setState({ width: 200, height: 200, absoluteWidth: 200, absoluteHeight: 200 });
   };
 
   onResize = (event, {element, size, handle}) => {
     this.setState({width: size.width, height: size.height});
   };
-  onResizeFixed = (event, {element, size, handle}) => {
+  onResizeAbsolute = (event, {element, size, handle}) => {
     this.setState((state) => {
-      let newTop = state.fixedTop;
-      let newLeft = state.fixedLeft;
-      if (handle.indexOf('n') > -1) {
-        const deltaHeight = size.height - state.fixedHeight;
-        newTop -= deltaHeight;
+      let newLeft = state.absoluteLeft;
+      let newTop = state.absoluteTop;
+      const deltaHeight = size.height - state.absoluteHeight;
+      const deltaWidth = size.width - state.absoluteWidth;
+      if (handle[0] === 'n') {
+        newTop -= deltaHeight / 2;
+      } else if (handle[0] === 's') {
+        newTop += deltaHeight / 2;
       }
-      if (handle.indexOf('w') > -1) {
-        const deltaWidth = size.width - state.fixedWidth;
-        newLeft -= deltaWidth;
+      if (handle[handle.length - 1] === 'w') {
+        newLeft -= deltaWidth / 2;
+      } else if (handle[handle.length - 1] === 'e') {
+        newLeft += deltaWidth / 2;
       }
+
       return {
-        fixedWidth: size.width,
-        fixedHeight: size.height,
-        fixedLeft: newLeft,
-        fixedTop: newTop
+        absoluteWidth: size.width,
+        absoluteHeight: size.height,
+        absoluteLeft: newLeft,
+        absoluteTop: newTop,
       };
     });
-  }
+  };
 
   render() {
     return (
@@ -106,19 +104,38 @@ export default class ExampleLayout extends React.Component<{}, {width: number, h
           <ResizableBox className="box" width={200} height={200} axis="none">
             <span className="text">Not resizable ("none" axis).</span>
           </ResizableBox>
-          <Resizable className="box" height={this.state.fixedHeight} width={this.state.fixedWidth} onResize={this.onResizeFixed} resizeHandles={['sw', 'se', 'nw', 'ne', 'w', 'e', 'n', 's']}>
+        </div>
+        <div className="layoutRoot absoluteLayout">
+          <ResizableBox className="box absolutely-positioned top-aligned left-aligned" height={200} width={200} resizeHandles={['se', 'e', 's']}>
+            <span className="text">{"Top-left Aligned"}</span>
+          </ResizableBox>
+          <ResizableBox className="box absolutely-positioned bottom-aligned left-aligned" height={200} width={200} resizeHandles={['ne', 'e', 'n']}>
+            <span className="text">{"Bottom-left Aligned"}</span>
+          </ResizableBox>
+          <Resizable
+            className="box absolutely-positioned center-aligned"
+            height={this.state.absoluteHeight}
+            width={this.state.absoluteWidth}
+            onResize={this.onResizeAbsolute}
+            resizeHandles={['sw', 'se', 'nw', 'ne', 'w', 'e', 'n', 's']}
+          >
             <div
               className="box"
               style={{
-                width: this.state.fixedWidth + 'px',
-                height: this.state.fixedHeight + 'px',
-                position: 'absolute',
-                left: this.state.fixedLeft,
-                top: this.state.fixedTop,
-              }}>
-              <span className="text">{"Absolutely positioned <Resizable> element. Resize in all directions."}</span>
+                width: this.state.absoluteWidth,
+                height: this.state.absoluteHeight,
+                margin: `${this.state.absoluteTop} 0 0 ${this.state.absoluteLeft}`,
+              }}
+            >
+              <span className="text">{"Raw use of <Resizable> element with controlled position. Resize and reposition in all directions"}</span>
             </div>
           </Resizable>
+          <ResizableBox className="box absolutely-positioned top-aligned right-aligned" height={200} width={200} resizeHandles={['sw', 'w', 's']}>
+            <span className="text">{"Top-right Aligned"}</span>
+          </ResizableBox>
+          <ResizableBox className="box absolutely-positioned bottom-aligned right-aligned" height={200} width={200} resizeHandles={['nw', 'w', 'n']}>
+            <span className="text">{"Bottom-right Aligned"}</span>
+          </ResizableBox>
         </div>
       </div>
     );

--- a/examples/ExampleLayout.js
+++ b/examples/ExampleLayout.js
@@ -5,7 +5,14 @@ import 'style-loader!css-loader!../css/styles.css';
 import 'style-loader!css-loader!./test.css';
 
 export default class ExampleLayout extends React.Component<{}, {width: number, height: number}> {
-  state = {width: 200, height: 200};
+  state = {
+    width: 200,
+    height: 200,
+    fixedWidth: 200,
+    fixedHeight: 200,
+    fixedLeft: 100,
+    fixedTop: 500
+  };
 
   onClick = () => {
     this.setState({width: 200, height: 200});
@@ -14,6 +21,26 @@ export default class ExampleLayout extends React.Component<{}, {width: number, h
   onResize = (event, {element, size, handle}) => {
     this.setState({width: size.width, height: size.height});
   };
+  onResizeFixed = (event, {element, size, handle}) => {
+    this.setState((state) => {
+      let newTop = state.fixedTop;
+      let newLeft = state.fixedLeft;
+      if (handle.indexOf('n') > -1) {
+        const deltaHeight = size.height - state.fixedHeight;
+        newTop -= deltaHeight;
+      }
+      if (handle.indexOf('w') > -1) {
+        const deltaWidth = size.width - state.fixedWidth;
+        newLeft -= deltaWidth;
+      }
+      return {
+        fixedWidth: size.width,
+        fixedHeight: size.height,
+        fixedLeft: newLeft,
+        fixedTop: newTop
+      };
+    });
+  }
 
   render() {
     return (
@@ -72,6 +99,19 @@ export default class ExampleLayout extends React.Component<{}, {width: number, h
           <ResizableBox className="box" width={200} height={200} axis="none">
             <span className="text">Not resizable ("none" axis).</span>
           </ResizableBox>
+          <Resizable className="box" height={this.state.fixedHeight} width={this.state.fixedWidth} onResize={this.onResizeFixed} resizeHandles={['sw', 'se', 'nw', 'ne', 'w', 'e', 'n', 's']}>
+            <div
+              className="box"
+              style={{
+                width: this.state.fixedWidth + 'px',
+                height: this.state.fixedHeight + 'px',
+                position: 'absolute',
+                left: this.state.fixedLeft,
+                top: this.state.fixedTop,
+              }}>
+              <span className="text">{"Absolutely positioned <Resizable> element. Resize in all directions."}</span>
+            </div>
+          </Resizable>
         </div>
       </div>
     );

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -119,7 +119,10 @@ export default class Resizable extends React.Component<Props, ResizableState> {
             deltaY += deltaTopSinceLast / this.props.transformScale;
           }
         }
-        this.lastHandleRect = handleRect;
+        this.lastHandleRect = {
+          top: handleRect.top,
+          left: handleRect.left,
+        };
       }
 
       // reverse delta if using top or left drag handles

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -24,8 +24,9 @@ export default class Resizable extends React.Component<Props, ResizableState> {
     slackW: 0, slackH: 0,
   };
 
-  lastTop: null;
-  lastLeft: null;
+  lastTop: ?number = null;
+  lastLeft: ?number = null;
+  draggingNode: ?HTMLElement = null;
 
   lockAspectRatio(width: number, height: number, aspectRatio: number): [number, number] {
     height = width / aspectRatio;
@@ -97,22 +98,23 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       const canDragY = (this.props.axis === 'both' || this.props.axis === 'y') && ['e', 'w'].indexOf(axis) === -1;
 
       // Check if handle's position has moved since last resizeHandler call - adjust deltas accordingly
-      if ((e.target instanceof window.HTMLElement)) {
-        const handleRect = e.target.getBoundingClientRect();
-        if (this.lastTop !== null && this.lastTop !== undefined && this.lastLeft !== null && this.lastLeft !== undefined) {
-          const deltaLeftSinceLast = handleRect.left - this.lastLeft;
-          const deltaTopSinceLast = handleRect.top - this.lastTop;
-          
-          if (canDragX && axis.indexOf('w') > -1) {
-            deltaX += deltaLeftSinceLast;
-          }
-          if(canDragY && axis.indexOf('n') > -1) {
-            deltaY += deltaTopSinceLast;
-          }
-        }
-        this.lastTop = handleRect.top;
-        this.lastLeft = handleRect.left;
+      if (this.draggingNode == null && e.target instanceof HTMLElement) {
+        this.draggingNode = e.target;
       }
+      const handleRect = this.draggingNode.getBoundingClientRect();
+      if (this.lastTop != null && this.lastLeft != null) {
+        const deltaLeftSinceLast = handleRect.left - this.lastLeft;
+        const deltaTopSinceLast = handleRect.top - this.lastTop;
+        
+        if (canDragX && axis.indexOf('w') > -1) {
+          deltaX += deltaLeftSinceLast;
+        }
+        if(canDragY && axis.indexOf('n') > -1) {
+          deltaY += deltaTopSinceLast;
+        }
+      }
+      this.lastTop = handleRect.top;
+      this.lastLeft = handleRect.left;
 
       // reverse delta if using top or left drag handles
       if (canDragX && axis[axis.length - 1] === 'w') {
@@ -138,7 +140,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
         // nothing
       } else if (handlerName === 'onResizeStop') {
         newState.slackW = newState.slackH = 0;
-        this.lastTop = this.lastLeft = null;
+        this.lastTop = this.lastLeft = this.draggingNode = null;
       } else {
         // Early return if no change after constraints
         if (width === this.props.width && height === this.props.height) return;

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -95,16 +95,23 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       const canDragX = (this.props.axis === 'both' || this.props.axis === 'x') && ['n', 's'].indexOf(axis) === -1;
       const canDragY = (this.props.axis === 'both' || this.props.axis === 'y') && ['e', 'w'].indexOf(axis) === -1;
 
-      // Check if handle's position has moved since last resizeHandler call - adjust deltas accordingly
+      /*
+        Track the element being dragged to account for changes in position.
+        If a handle's position is changed between callbacks, we need to factor this in to the next callback
+      */
       if (this.draggingNode == null && e.target instanceof HTMLElement) {
         this.draggingNode = e.target;
       }
       if (this.draggingNode instanceof HTMLElement) {
         const handleRect = this.draggingNode.getBoundingClientRect();
         if (this.lastHandleRect != null) {
+          // Find how much the handle has moved since the last callback
           const deltaLeftSinceLast = handleRect.left - this.lastHandleRect.left;
           const deltaTopSinceLast = handleRect.top - this.lastHandleRect.top;
           
+          // If the handle has repositioned on either axis since last render,
+          // we need to increase our callback values by this much.
+          // Only checking 'n', 'w' since resizing by 's', 'w' won't affect the overall position on page
           if (canDragX && axis[axis.length - 1] === 'w') {
             deltaX += deltaLeftSinceLast / this.props.transformScale;
           }

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -108,10 +108,10 @@ export default class Resizable extends React.Component<Props, ResizableState> {
           const deltaTopSinceLast = handleRect.top - this.lastTop;
           
           if (canDragX && axis.indexOf('w') > -1) {
-            deltaX += deltaLeftSinceLast;
+            deltaX += deltaLeftSinceLast / this.props.transformScale;
           }
           if(canDragY && axis.indexOf('n') > -1) {
-            deltaY += deltaTopSinceLast;
+            deltaY += deltaTopSinceLast / this.props.transformScale;
           }
         }
         this.lastTop = handleRect.top;

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -101,20 +101,22 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       if (this.draggingNode == null && e.target instanceof HTMLElement) {
         this.draggingNode = e.target;
       }
-      const handleRect = this.draggingNode.getBoundingClientRect();
-      if (this.lastTop != null && this.lastLeft != null) {
-        const deltaLeftSinceLast = handleRect.left - this.lastLeft;
-        const deltaTopSinceLast = handleRect.top - this.lastTop;
-        
-        if (canDragX && axis.indexOf('w') > -1) {
-          deltaX += deltaLeftSinceLast;
+      if (this.draggingNode instanceof HTMLElement) {
+        const handleRect = this.draggingNode.getBoundingClientRect();
+        if (this.lastTop != null && this.lastLeft != null) {
+          const deltaLeftSinceLast = handleRect.left - this.lastLeft;
+          const deltaTopSinceLast = handleRect.top - this.lastTop;
+          
+          if (canDragX && axis.indexOf('w') > -1) {
+            deltaX += deltaLeftSinceLast;
+          }
+          if(canDragY && axis.indexOf('n') > -1) {
+            deltaY += deltaTopSinceLast;
+          }
         }
-        if(canDragY && axis.indexOf('n') > -1) {
-          deltaY += deltaTopSinceLast;
-        }
+        this.lastTop = handleRect.top;
+        this.lastLeft = handleRect.left;
       }
-      this.lastTop = handleRect.top;
-      this.lastLeft = handleRect.left;
 
       // reverse delta if using top or left drag handles
       if (canDragX && axis[axis.length - 1] === 'w') {

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -107,10 +107,10 @@ export default class Resizable extends React.Component<Props, ResizableState> {
           const deltaLeftSinceLast = handleRect.left - this.lastLeft;
           const deltaTopSinceLast = handleRect.top - this.lastTop;
           
-          if (canDragX && axis.indexOf('w') > -1) {
+          if (canDragX && axis[axis.length - 1] === 'w') {
             deltaX += deltaLeftSinceLast / this.props.transformScale;
           }
-          if(canDragY && axis.indexOf('n') > -1) {
+          if(canDragY && axis[0] === 'n') {
             deltaY += deltaTopSinceLast / this.props.transformScale;
           }
         }

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -2,10 +2,9 @@
 import React from 'react';
 import type {Node as ReactNode} from 'react';
 import {DraggableCore} from 'react-draggable';
-
 import {cloneElement} from './utils';
 import {resizableProps} from "./propTypes";
-import type {ResizeHandleAxis, Props, ResizableState, DragCallbackData} from './propTypes';
+import type {ResizeHandleAxis, Props, ResizableState, DragCallbackData, ClientRect} from './propTypes';
 
 export default class Resizable extends React.Component<Props, ResizableState> {
   static propTypes = resizableProps;
@@ -24,8 +23,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
     slackW: 0, slackH: 0,
   };
 
-  lastTop: ?number = null;
-  lastLeft: ?number = null;
+  lastHandleRect: ?ClientRect = null;
   draggingNode: ?HTMLElement = null;
 
   lockAspectRatio(width: number, height: number, aspectRatio: number): [number, number] {
@@ -103,9 +101,9 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       }
       if (this.draggingNode instanceof HTMLElement) {
         const handleRect = this.draggingNode.getBoundingClientRect();
-        if (this.lastTop != null && this.lastLeft != null) {
-          const deltaLeftSinceLast = handleRect.left - this.lastLeft;
-          const deltaTopSinceLast = handleRect.top - this.lastTop;
+        if (this.lastHandleRect != null) {
+          const deltaLeftSinceLast = handleRect.left - this.lastHandleRect.left;
+          const deltaTopSinceLast = handleRect.top - this.lastHandleRect.top;
           
           if (canDragX && axis[axis.length - 1] === 'w') {
             deltaX += deltaLeftSinceLast / this.props.transformScale;
@@ -114,8 +112,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
             deltaY += deltaTopSinceLast / this.props.transformScale;
           }
         }
-        this.lastTop = handleRect.top;
-        this.lastLeft = handleRect.left;
+        this.lastHandleRect = handleRect;
       }
 
       // reverse delta if using top or left drag handles
@@ -142,7 +139,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
         // nothing
       } else if (handlerName === 'onResizeStop') {
         newState.slackW = newState.slackH = 0;
-        this.lastTop = this.lastLeft = this.draggingNode = null;
+        this.lastHandleRect = this.draggingNode = null;
       } else {
         // Early return if no change after constraints
         if (width === this.props.width && height === this.props.height) return;

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -97,7 +97,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       const canDragY = (this.props.axis === 'both' || this.props.axis === 'y') && ['e', 'w'].indexOf(axis) === -1;
 
       // Check if handle's position has moved since last resizeHandler call - adjust deltas accordingly
-      if ((e.target instanceof window.HTMLInputElement)) {
+      if ((e.target instanceof window.HTMLElement)) {
         const handleRect = e.target.getBoundingClientRect();
         if (this.lastTop !== null && this.lastTop !== undefined && this.lastLeft !== null && this.lastLeft !== undefined) {
           const deltaLeftSinceLast = handleRect.left - this.lastLeft;

--- a/lib/Resizable.js
+++ b/lib/Resizable.js
@@ -24,6 +24,9 @@ export default class Resizable extends React.Component<Props, ResizableState> {
     slackW: 0, slackH: 0,
   };
 
+  lastTop: null;
+  lastLeft: null;
+
   lockAspectRatio(width: number, height: number, aspectRatio: number): [number, number] {
     height = width / aspectRatio;
     width = height * aspectRatio;
@@ -93,6 +96,24 @@ export default class Resizable extends React.Component<Props, ResizableState> {
       const canDragX = (this.props.axis === 'both' || this.props.axis === 'x') && ['n', 's'].indexOf(axis) === -1;
       const canDragY = (this.props.axis === 'both' || this.props.axis === 'y') && ['e', 'w'].indexOf(axis) === -1;
 
+      // Check if handle's position has moved since last resizeHandler call - adjust deltas accordingly
+      if ((e.target instanceof window.HTMLInputElement)) {
+        const handleRect = e.target.getBoundingClientRect();
+        if (this.lastTop !== null && this.lastTop !== undefined && this.lastLeft !== null && this.lastLeft !== undefined) {
+          const deltaLeftSinceLast = handleRect.left - this.lastLeft;
+          const deltaTopSinceLast = handleRect.top - this.lastTop;
+          
+          if (canDragX && axis.indexOf('w') > -1) {
+            deltaX += deltaLeftSinceLast;
+          }
+          if(canDragY && axis.indexOf('n') > -1) {
+            deltaY += deltaTopSinceLast;
+          }
+        }
+        this.lastTop = handleRect.top;
+        this.lastLeft = handleRect.left;
+      }
+
       // reverse delta if using top or left drag handles
       if (canDragX && axis[axis.length - 1] === 'w') {
         deltaX = -deltaX;
@@ -117,6 +138,7 @@ export default class Resizable extends React.Component<Props, ResizableState> {
         // nothing
       } else if (handlerName === 'onResizeStop') {
         newState.slackW = newState.slackH = 0;
+        this.lastTop = this.lastLeft = null;
       } else {
         // Early return if no change after constraints
         if (width === this.props.width && height === this.props.height) return;

--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -23,6 +23,14 @@ export type ResizeCallbackData = {|
   size: {|width: number, height: number|},
   handle: ResizeHandleAxis
 |};
+export type ClientRect = {|
+  left: number;
+  width: number;
+  right: number;
+  top: number;
+  bottom: number;
+  height: number;
+|};
 
 // <Resizable>
 export type Props = {|

--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -25,11 +25,7 @@ export type ResizeCallbackData = {|
 |};
 export type ClientRect = {|
   left: number;
-  width: number;
-  right: number;
   top: number;
-  bottom: number;
-  height: number;
 |};
 
 // <Resizable>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = {
   context: __dirname,
   entry: {
-    test: "./test/test.js",
+    test: "./examples/example.js",
   },
   output: {
     path: path.join(__dirname, "dist"),


### PR DESCRIPTION
## What's wrong?
Hey, love the library. Works really well for the most part but, as a few different issues have mentioned, it has some serious issues when resizing from the left or the top, using anything other than top-left positioning. The following open issues are just some that have documented the issue:

- https://github.com/STRML/react-resizable/issues/131
- https://github.com/STRML/react-resizable/issues/119

I've put together a minimal codesandbox to demonstrate the issue as well: 
https://codesandbox.io/s/react-playground-vwlpk?file=/index.js

Samples from the above codesandbox:
* Dragging to the right: smooth
[![Image from Gyazo](https://i.gyazo.com/547b6702a5910a58dd11d65c6efad055.gif)](https://gyazo.com/547b6702a5910a58dd11d65c6efad055)

* Dragging to the left: jumpy/flickering
[![Image from Gyazo](https://i.gyazo.com/f727608700cdefe106de907809c34c6e.gif)](https://gyazo.com/f727608700cdefe106de907809c34c6e)

## The Cause?
The problem is that on subsequent calls of the `resizeHandler` function, it's reporting a resize based on the `deltaX` and `deltaY` of the movement. However, if calling back through the `onResize` prop results in a position change (for instance, if you are using right-based absolute positioning as in my example above, or if you are manually updating the top/left positions based on the resize), then the drag handle itself might be moved by the re-render, so the next call to `resizeHandler` will report that the handle has moved, even though this is a prop-driven movement rather than a mouse-event driven one.

## The solution
I've added a few lines to track a reference to the drag handle element in the document and in every call of `resizeHandler`, I'm comparing the new top and left of the element on the page with the previous values. A difference in these values will be a result of a positioning change, and so we want to account for this in our `deltaX`/`deltaY` values.

If dragging any handle with an `'n'` in it and its position has changed, then our event's reported `deltaY` value will either be larger or smaller than we expect it to be (because this value will include the position change). Adding this y-position differential to the delta value accounts for this and keeps the callback only reporting on movement that was caused by the mouse event. The same goes for the x-axis and any handle with a `'w'` in it.

## Demo
I've added a new example to the examples demo page which features a new box with omni-directional movement. This can be used to demonstrate a before and after and also shows much more power behind this library.

e.g.
* Old - omni-directional box stuttering dragging top and left
![ezgif-3-9726531015d8](https://user-images.githubusercontent.com/35919832/83949830-dc31f180-a81d-11ea-820a-6c64ff57cb88.gif)

* New - omni-directional box smoothly resizing in all directions
![ezgif-3-8d801f0a91eb](https://user-images.githubusercontent.com/35919832/83949750-6463c700-a81d-11ea-9ea3-4940ea87a478.gif)


Let me know of any issues you come across with it and have a good day!